### PR TITLE
Add translation of Ñ to Morse code

### DIFF
--- a/app/src/main/java/rocks/poopjournal/morse/MainActivity.java
+++ b/app/src/main/java/rocks/poopjournal/morse/MainActivity.java
@@ -319,6 +319,8 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                 return "..--";
             case "я":
                 return ".-.-";
+            case "ñ":
+                return "--.--";
             default:
                 return "";
         }
@@ -402,7 +404,8 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                 return "8";
             case "----.":
                 return "9";
-
+            case "--.--":
+                return "ñ";
         }
 
         return "";


### PR DESCRIPTION
Fixes Crazy-Marvin/Morse#122

- The character `Ñ` translates to `--.--` per the documentation on [morsecode.world](https://morsecode.world/international/morse2.html)
- Added a switch case to handle the encoding as well as decoding of this character.

Screenshots:
| Before | After |
| -- | -- |
| ![Screenshot_20221030-130829](https://user-images.githubusercontent.com/87667048/198868310-bc0d68ae-a96b-4609-bcaa-75ccc7a6cc34.png) | ![Screenshot_20221030-131136](https://user-images.githubusercontent.com/87667048/198868306-d678265f-13bb-4134-9d02-59712db0501d.png) |
| | ![Screenshot_20221030-131219](https://user-images.githubusercontent.com/87667048/198868299-59aba281-a27a-456a-916d-eb3cc84be31b.png) |
| | ![Screenshot_20221030-131253](https://user-images.githubusercontent.com/87667048/198868289-ea8942c1-f30c-4efd-a565-0dbc7c19f968.png) |
