### PR TITLE
Fix NPE when releasing camera

### DIFF
--- a/app/src/main/java/rocks/poopjournal/morse/MainActivity.java
+++ b/app/src/main/java/rocks/poopjournal/morse/MainActivity.java
@@ -513,7 +513,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
 
 
                     if (!Build.MANUFACTURER.equals("HUAWEI")) {
-                        camera = Camera.open();
+                        openCamera();
                     }
 
 
@@ -528,10 +528,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                             turnOff();
                         }
                     }
-
-                    camera.release();
-                    camera = null;
-
+                    releaseCamera();
                 }
             } else {
                 if (!TextUtils.isEmpty(input.getText().toString())) {
@@ -561,8 +558,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                             turnOff();
                         }
                     }
-                    camera.release();
-                    camera = null;
+                    releaseCamera();
                 }
             }
         });
@@ -997,7 +993,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
     public void turnOn() {
         try {
             if (android.os.Build.MANUFACTURER.equals("HUAWEI")) {
-                camera = Camera.open();
+                openCamera();
             }
 
             Log.d("cameraMorseCheck","turning camera on at " + System.currentTimeMillis());
@@ -1234,7 +1230,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                 telegraphPlayer.start();
             } else {
                 time = System.currentTimeMillis();
-                camera = Camera.open();
+                openCamera();
                 turnOn();
             }
             return true;
@@ -1255,19 +1251,28 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
 
                 if (System.currentTimeMillis() - time >= 200) {
                     turnOff();
-                    camera.release();
-                    camera = null;
+                    releaseCamera();
                 } else {
                     final Handler handler = new Handler(Looper.getMainLooper());
                     handler.postDelayed(() -> {
                         turnOff();
-                        camera.release();
-                        camera = null;
+                        releaseCamera();
                     }, 100);
                 }
             }
             return true;
         }
         return false;
+    }
+
+    private void openCamera() {
+        camera = Camera.open();
+    }
+
+    private void releaseCamera() {
+        if (camera != null) {
+            camera.release();
+            camera = null;
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 09 15:32:18 PKT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
When tapping rapidly on the telegraph key, the camera is released, either directly or delayed via a posted Runnable. When tapping rapidly, the delayed runnable would run after a synchronous release of the camera, in a state where the camera would be null.

Extract open and release of the camera to two methods and protect the release with a null check.

Also update the Gradle wrapper to 8.0 to be compatible with the latest stable version of Android Studio (Giraffe).