### PR TITLE
Enable copy paste for morse code

### DIFF
--- a/app/src/main/java/rocks/poopjournal/morse/EditTextTouch.java
+++ b/app/src/main/java/rocks/poopjournal/morse/EditTextTouch.java
@@ -7,7 +7,6 @@ import android.widget.EditText;
 
 @SuppressLint("AppCompatCustomView")
 public class EditTextTouch extends EditText {
-    public final OnTouchListener mOnTouchListener = (v, rawEvent) -> false;
 
     public EditTextTouch(Context context) {
         super(context);

--- a/app/src/main/java/rocks/poopjournal/morse/MainActivity.java
+++ b/app/src/main/java/rocks/poopjournal/morse/MainActivity.java
@@ -155,9 +155,6 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
             }
         }
     };
-    private View.OnTouchListener otl = (v, event) -> {
-        return true; // the listener has consumed the event
-    };
 
     public static void setMargins(View v, int l, int t, int r, int b) {
         if (v.getLayoutParams() instanceof ViewGroup.MarginLayoutParams) {
@@ -766,7 +763,6 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                 input.setText("");
                 output.setText("");
                 textToMorse.set(false);
-                input.setOnTouchListener(otl);
 
                 bottomNavigation.setVisibility(View.VISIBLE);
                 morseInputContainer.setVisibility(View.VISIBLE);
@@ -801,14 +797,8 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
                 buttonOne.setText("TEXT");
                 buttonTwo.setText("MORSE");
                 textToMorse.set(true);
-                input.setOnTouchListener((v16, event) -> {
-                    v16.setOnTouchListener(input.mOnTouchListener);
-                    return false;
-                });
                 bottomNavigation.setVisibility(View.GONE);
                 morseInputContainer.setVisibility(View.GONE);
-
-
             }
         });
 


### PR DESCRIPTION
Text actions, like copy and paste, were only enabled for text but not morse code. This was caused by a touch listener that swallowed touch events when the text view was in the "morse" mode.

Remove the touch event swallowing touch listener, and a touch listener in the text state that just returned false.

Resolves #76